### PR TITLE
fix templating error for manage.py

### DIFF
--- a/migrate/versioning/templates/manage/default.py_tmpl
+++ b/migrate/versioning/templates/manage/default.py_tmpl
@@ -5,6 +5,7 @@ from migrate.versioning.shell import main
 import six
 _vars = locals().copy()
 del _vars['__template_name__']
+del _vars['six']
 _vars.pop('repository_name', None)
 defaults = ", ".join(["%s='%s'" % var for var in six.iteritems(_vars)])
 }}


### PR DESCRIPTION
Fixes [version_control: invalid syntax near module 'six'](https://code.google.com/p/sqlalchemy-migrate/issues/detail?id=171&q=invalid)

The variable `six` was not templating nicely, it would appear as: 

``` python
main(debug='False', six='<module 'six' from '/usr/lib/python2.7/dist-packages/six.pyc'>')
```

My fix is just to pop `six` from the `_var` variable which was holding `locals().copy()`.

The alternative fix to this would be to print the string with escaped quotes so we don't have malformed strings.
