### PR TITLE
fixes bug 171, 'six' module gets outputted incorrect to <REPO>/manage.py

### DIFF
--- a/migrate/versioning/templates/manage/default.py_tmpl
+++ b/migrate/versioning/templates/manage/default.py_tmpl
@@ -6,6 +6,7 @@ import six
 _vars = locals().copy()
 del _vars['__template_name__']
 _vars.pop('repository_name', None)
+_vars.pop("six", None)
 defaults = ", ".join(["%s='%s'" % var for var in six.iteritems(_vars)])
 }}
 


### PR DESCRIPTION
https://code.google.com/p/sqlalchemy-migrate/issues/detail?id=171

Fixed issue where you get a syntax error running manage.py because it outputs the 'six' module in the default.py_tmpl template script, by just popping the 'six' module from the copy of locals()
