### PR TITLE
Update migration template to allow JSON

### DIFF
--- a/migrate/versioning/templates/script/default.py_tmpl
+++ b/migrate/versioning/templates/script/default.py_tmpl
@@ -1,5 +1,6 @@
 from sqlalchemy import *
 from migrate import *
+from migrations.versions import *
 
 
 def upgrade(migrate_engine):


### PR DESCRIPTION
now in the __init__.py next to all the migrations one can add this line and use JSON in the migrations as per the models using JSON

This is needed by one of my projects, surely it will be my many more

    # __init__.py file in migrations.versions in the project
    from sqlalchemy.dialects.postgresql import JSON

