### PR TITLE
inspect.getargspec() is deprecated in Python 3.

### DIFF
--- a/migrate/versioning/script/py.py
+++ b/migrate/versioning/script/py.py
@@ -4,14 +4,13 @@
 import shutil
 import warnings
 import logging
-import inspect
 
 import migrate
 from migrate.versioning import genmodel, schemadiff
 from migrate.versioning.config import operations
 from migrate.versioning.template import Template
 from migrate.versioning.script import base
-from migrate.versioning.util import import_path, load_model, with_engine
+from migrate.versioning.util import getargspec, import_path, load_model, with_engine
 from migrate.exceptions import MigrateDeprecationWarning, InvalidScriptError, ScriptError
 import six
 from six.moves import StringIO
@@ -141,7 +140,7 @@ class PythonScript(base.BaseScript):
         script_func = self._func(funcname)
 
         # check for old way of using engine
-        if not inspect.getargspec(script_func)[0]:
+        if not getargspec(script_func)[0]:
             raise TypeError("upgrade/downgrade functions must accept engine"
                 " parameter (since version 0.5.4)")
 

--- a/migrate/versioning/shell.py
+++ b/migrate/versioning/shell.py
@@ -11,7 +11,7 @@ from optparse import OptionParser, BadOptionError
 from migrate import exceptions
 from migrate.versioning import api
 from migrate.versioning.config import *
-from migrate.versioning.util import asbool
+from migrate.versioning.util import asbool, getargspec
 import six
 
 
@@ -108,7 +108,7 @@ def main(argv=None, **kwargs):
         parser.error("Invalid command %s" % command)
 
     parser.set_usage(inspect.getdoc(command_func))
-    f_args, f_varargs, f_kwargs, f_defaults = inspect.getargspec(command_func)
+    f_args, f_varargs, f_kwargs, f_defaults = getargspec(command_func)
     for arg in f_args:
         parser.add_option(
             "--%s" % arg,

--- a/migrate/versioning/util/__init__.py
+++ b/migrate/versioning/util/__init__.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """.. currentmodule:: migrate.versioning.util"""
 
+import inspect
 import warnings
 import logging
 from decorator import decorator
@@ -185,3 +186,9 @@ class Memoize(object):
         if args not in self.memo:
             self.memo[args] = self.fn(*args)
         return self.memo[args]
+
+
+if getattr(inspect, "getfullargspec", None):
+    getargspec = inspect.getfullargspec
+else:
+    getargspec = inspect.getargspec


### PR DESCRIPTION
inspect.signature() or inspect.getfullargspec() should be used instead.

This eliminates deprecation warnings in Python 3.