### PR TITLE
Updates to work with Pandas & Redshift

### DIFF
--- a/migrate/changeset/databases/visitor.py
+++ b/migrate/changeset/databases/visitor.py
@@ -17,6 +17,7 @@ DIALECTS = {
     "sqlite": sqlite.SQLiteDialect,
     "postgres": postgres.PGDialect,
     "postgresql": postgres.PGDialect,
+    "redshift": postgres.PGDialect,
     "mysql": mysql.MySQLDialect,
     "oracle": oracle.OracleDialect,
     "firebird": firebird.FBDialect,

--- a/migrate/changeset/schema.py
+++ b/migrate/changeset/schema.py
@@ -540,8 +540,7 @@ class ChangesetColumn(object):
         return alter_column(self, *p, **k)
 
     def create(self, table=None, index_name=None, unique_name=None,
-               primary_key_name=None, populate_default=True, connection=None, 
-	       engine=None, **kwargs):
+               primary_key_name=None, populate_default=True, connection=None, engine=None, **kwargs):
         """Create this column in the database.
 
         Assumes the given table exists. ``ALTER TABLE ADD COLUMN``,
@@ -573,7 +572,7 @@ populated with defaults
             self._check_sanity_constraints(cons)
 
         self.add_to_table(table)
-	if engine is None:
+        if engine is None:
             engine = self.table.bind
         visitorcallable = get_engine_visitor(engine, 'columngenerator')
         engine._run_visitor(visitorcallable, self, connection, **kwargs)

--- a/migrate/changeset/schema.py
+++ b/migrate/changeset/schema.py
@@ -540,7 +540,8 @@ class ChangesetColumn(object):
         return alter_column(self, *p, **k)
 
     def create(self, table=None, index_name=None, unique_name=None,
-               primary_key_name=None, populate_default=True, connection=None, **kwargs):
+               primary_key_name=None, populate_default=True, connection=None, 
+	       engine=None, **kwargs):
         """Create this column in the database.
 
         Assumes the given table exists. ``ALTER TABLE ADD COLUMN``,
@@ -572,7 +573,8 @@ populated with defaults
             self._check_sanity_constraints(cons)
 
         self.add_to_table(table)
-        engine = self.table.bind
+	if engine is None:
+            engine = self.table.bind
         visitorcallable = get_engine_visitor(engine, 'columngenerator')
         engine._run_visitor(visitorcallable, self, connection, **kwargs)
 


### PR DESCRIPTION
Minor updates to work with Pandas and AWS Redshift

Column.create(\<table\>) if passing a Pandas Read SQL Table it would get confused about the table.bind object as the engine would point to a pandas.io.sql.SQLDatabase, which is a wrapper around sqlalchemy.engine

AWS Redshift is just Postgresql on OLAP, there are some postgresql language bindings that don't work, but the postgres.PGDialect binding will work.