### PR TITLE
Fix sql migrations support

### DIFF
--- a/migrate/versioning/schema.py
+++ b/migrate/versioning/schema.py
@@ -77,7 +77,7 @@ class ControlledSchema(object):
         Uses self.version for start version and engine.name
         to get database name.
         """
-        database = self.engine.name
+        database = self.repository
         start_ver = self.version
         changeset = self.repository.changeset(database, start_ver, version)
         return changeset

--- a/migrate/versioning/version.py
+++ b/migrate/versioning/version.py
@@ -207,7 +207,7 @@ class Version(object):
         for db in (database, 'default'):
             # Try to return a .sql script first
             try:
-                return self.sql[db][operation]
+                return self.sql[str(db)][operation]
             except KeyError:
                 continue  # No .sql script exists
 


### PR DESCRIPTION
Got this error previously:

```
Traceback (most recent call last):
  File "stats/manage.py", line 8, in <module>
    main(debug='True', url=conn, repository='stats')
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/shell.py", line 209, in main
    ret = command_func(**kwargs)
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/api.py", line 186, in upgrade
    return _migrate(url, repository, version, upgrade=True, err=err, **opts)
  File "<decorator-gen-15>", line 2, in _migrate
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/util/__init__.py", line 160, in with_engine
    return f(*a, **kw)
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/api.py", line 345, in _migrate
    changeset = schema.changeset(version)
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/schema.py", line 82, in changeset
    changeset = self.repository.changeset(database, start_ver, version)
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/repository.py", line 225, in changeset
    changes = [self.version(v).script(database, op) for v in versions]
  File "/usr/local/lib/python2.7/site-packages/migrate/versioning/version.py", line 204, in script
    "There is no script for %d version" % self.version
AssertionError: There is no script for 38 version
```