### PR TITLE
Use raw strings where necessary for compatibility with Python 3.6

### DIFF
--- a/migrate/changeset/__init__.py
+++ b/migrate/changeset/__init__.py
@@ -9,7 +9,7 @@ import re
 import sqlalchemy
 from sqlalchemy import __version__ as _sa_version
 
-_sa_version = tuple(int(re.match("\d+", x).group(0)) for x in _sa_version.split("."))
+_sa_version = tuple(int(re.match(r"\d+", x).group(0)) for x in _sa_version.split("."))
 SQLA_07 = _sa_version >= (0, 7)
 SQLA_08 = _sa_version >= (0, 8)
 SQLA_09 = _sa_version >= (0, 9)

--- a/migrate/changeset/databases/sqlite.py
+++ b/migrate/changeset/databases/sqlite.py
@@ -61,7 +61,7 @@ class SQLiteHelper(SQLiteCommon):
             table_name=table.name
         ).fetchone()[0]
 
-        UNIQUE_PATTERN = "CONSTRAINT (\w+) UNIQUE \(([^\)]+)\)"
+        UNIQUE_PATTERN = r"CONSTRAINT (\w+) UNIQUE \(([^\)]+)\)"
         constraints = []
         for name, cols in re.findall(UNIQUE_PATTERN, data):
             # Filter out any columns that were dropped from the table.
@@ -69,7 +69,7 @@ class SQLiteHelper(SQLiteCommon):
             if columns:
                 constraints.extend(UniqueConstraint(*columns, name=name))
 
-        FKEY_PATTERN = "CONSTRAINT (\w+) FOREIGN KEY \(([^\)]+)\)"
+        FKEY_PATTERN = r"CONSTRAINT (\w+) FOREIGN KEY \(([^\)]+)\)"
         for name, cols in re.findall(FKEY_PATTERN, data):
             # Filter out any columns that were dropped from the table.
             columns = self._filter_columns(cols, table)

--- a/migrate/changeset/schema.py
+++ b/migrate/changeset/schema.py
@@ -200,7 +200,7 @@ class MyMeta(sqlalchemy.sql.visitors.VisitableType, abc.ABCMeta, object):
 
 
 class ColumnDelta(six.with_metaclass(MyMeta, DictMixin, sqlalchemy.schema.SchemaItem)):
-    """Extracts the differences between two columns/column-parameters
+    r"""Extracts the differences between two columns/column-parameters
 
         May receive parameters arranged in several different ways:
 

--- a/migrate/versioning/script/sql.py
+++ b/migrate/versioning/script/sql.py
@@ -47,7 +47,7 @@ class SqlScript(base.BaseScript):
                 # (and committing transaction, which is contradictory to
                 # the whole idea of ROLLBACK)
                 ignored_statements = ('BEGIN', 'END', 'COMMIT')
-                ignored_regex = re.compile('^\s*(%s).*;?$' % '|'.join(ignored_statements),
+                ignored_regex = re.compile(r'^\s*(%s).*;?$' % '|'.join(ignored_statements),
                                            re.IGNORECASE)
 
                 # NOTE(ihrachys): script may contain multiple statements, and


### PR DESCRIPTION
Python 3.6 deprecates invalid escapes in strings (previously they were just ignored) and they will become errors in 3.8 or 3.9. When backslashes are intended to be included literally, raw strings should be used. This PR fixes these instances in sqlalchemy-migrate.