### PR TITLE
Change contextual_connect to connect to address depreciation warning

### DIFF
--- a/migrate/changeset/databases/visitor.py
+++ b/migrate/changeset/databases/visitor.py
@@ -73,7 +73,7 @@ def run_single_visitor(engine, visitorcallable, element,
     with support for migrate visitors.
     """
     if connection is None:
-        conn = engine.contextual_connect(close_with_result=False)
+        conn = engine.connect(close_with_result=False)
     else:
         conn = connection
     visitor = visitorcallable(engine.dialect, conn)


### PR DESCRIPTION
contextual_connect seems to be depreciated as per: https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.Engine.contextual_connect
Also it throws a bunch of warnings which pollutes my unit test output.